### PR TITLE
Adding 'debug' method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@
   // Public
   // ------
 
-  var methods = ['log', 'info', 'warn', 'error']
+  var methods = ['debug', 'log', 'info', 'warn', 'error']
   methods.forEach(function(method) {
     Logdown.prototype[method] = function() {
       var preparedOutput
@@ -152,7 +152,7 @@
         // http://stackoverflow.com/questions/5538972/
         //  console-log-apply-not-working-in-ie9
         Function.prototype.apply.call(
-          console[method],
+          console[method] || console.log,
           console,
           [preparedOutput.parsedText]
             .concat(preparedOutput.styles,
@@ -180,6 +180,12 @@
             '\u001b[' + ansiColors.colors.blue[0] + 'm' +
             'ℹ' +
             '\u001b[' + ansiColors.colors.blue[1] + 'm ' +
+            preparedOutput.parsedText
+        } else if (method === 'debug') {
+          preparedOutput.parsedText =
+            '\u001b[' + ansiColors.colors.gray[0] + 'm' +
+            '🐛' +
+            '\u001b[' + ansiColors.colors.gray[1] + 'm ' +
             preparedOutput.parsedText
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@
           args.push(preparedOutput.notText)
         }
 
-        console[method].apply(
+        (console[method] || console.log).apply(
           console,
           args
         )

--- a/test/browser/logging-methods.js
+++ b/test/browser/logging-methods.js
@@ -9,7 +9,7 @@
   sinon.assert.expose(chai.assert, {prefix: ''})
   var assert = chai.assert
 
-  var methods = ['log', 'info', 'warn', 'error']
+  var methods = ['debug', 'log', 'info', 'warn', 'error']
   methods.forEach(function(method) {
     describe('Logdown::' + method, function() {
       var sandbox

--- a/test/server/logging-methods.js
+++ b/test/server/logging-methods.js
@@ -44,13 +44,18 @@ var ansiColors = {
   }
 };
 
-var methods = ['log', 'info', 'warn', 'error']
+var methods = ['debug', 'log', 'info', 'warn', 'error']
 methods.forEach(function(method) {
   describe('Logdown::' + method, function() {
     var sandbox
     var symbol = ''
 
-    if (method === 'info') {
+    if (method === 'debug') {
+      symbol =
+        '\u001b[' + ansiColors.colors.gray[0] + 'm' +
+        '🐛' +
+        '\u001b[' + ansiColors.colors.gray[1] + 'm '
+    } else if (method === 'info') {
       symbol =
         '\u001b[' + ansiColors.colors.blue[0] + 'm' +
         'ℹ' +

--- a/test/server/logging-methods.js
+++ b/test/server/logging-methods.js
@@ -73,6 +73,7 @@ methods.forEach(function(method) {
     }
 
     beforeEach(function() {
+      global.console[method] = global.console[method] || global.console.log;
       sandbox = sinon.sandbox.create()
       sandbox.stub(global.console, method)
 


### PR DESCRIPTION
Adding the `debug` method alongside log,warn, etc.

Falls back to `console.log` if the debug method is not available on `window.console`