### PR TITLE
feat: Add plaintext option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare namespace logdown {
     markdown?: boolean;
     prefix?: string;
     prefixColor?: string;
+    plaintext?: boolean;
   }
 
   interface TransportOptions {

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ $ NODE_DEBUG=foo node example/node.js
 The corresponding command for browsers is:
 
 ```js
-window.localStorage.debug = 'foo';
+window.localStorage.debug = 'foo'
 ```
 
 Multiple comma-separated logger names and wildcards can be specified as well.
@@ -71,9 +71,9 @@ Multiple comma-separated logger names and wildcards can be specified as well.
 With the `isEnabled` state a specific logger instance can always be enabled, independent of the `NODE_DEBUG` setting:
 
 ```js
-const logger = require('logdown')('foo');
-logger.state.isEnabled = true;
-logger.log('I will always log.');
+const logger = require('logdown')('foo')
+logger.state.isEnabled = true
+logger.log('I will always log.')
 ```
 
 ### Logging
@@ -183,7 +183,7 @@ logging function will use only one argument (i.e. `console.log('[my project] my 
 of `console.log('[my project]', 'my message')`.).
 
 ```js
-const logger = logdown('foo', { plaintext: 'true' });
+const logger = logdown('foo', { plaintext: 'true' })
 ```
 
 ### State

--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,19 @@ const logger = logdown('foo', {
 })
 ```
 
+#### `plaintext` (Node.js only)
+
+- type: 'Boolean'
+- default: `false`
+
+This will enable plaintext logging, that means, all objects will be stringified and the
+logging function will use only one argument (i.e. `console.log('[my project] my message')` instead
+of `console.log('[my project]', 'my message')`.).
+
+```js
+const logger = logdown('foo', { plaintext: 'true' });
+```
+
 ### State
 
 #### `isEnabled`

--- a/src/base.js
+++ b/src/base.js
@@ -53,10 +53,12 @@ module.exports = function () {
     var markdown = opts.markdown === undefined ? true : Boolean(opts.markdown)
     var prefixColor = opts.prefixColor || Logdown._getNextPrefixColor()
     var logger = opts.logger || console
+    var plaintext = Boolean(opts.plaintext)
 
     return {
       logger: logger,
       markdown: markdown,
+      plaintext: plaintext,
       prefix: prefix,
       prefixColor: prefixColor
     }

--- a/src/node.js
+++ b/src/node.js
@@ -85,7 +85,7 @@ Logdown._getNextPrefixColor = (function () {
 Logdown.prototype._getDecoratedPrefix = function (method) {
   var decoratedPrefix
 
-  if (isColorSupported()) {
+  if (isColorSupported() && !this.opts.plaintext) {
     // If is a hex color value
     if (this.opts.prefixColor[0] === '#') {
       decoratedPrefix = chalk.bold.hex(this.opts.prefixColor)(this.opts.prefix)
@@ -127,6 +127,15 @@ Logdown.prototype._prepareOutput = function (args, method) {
       preparedOutput.push(arg)
     }
   }, this)
+
+  if (this.opts.plaintext) {
+    const outputString = preparedOutput.reduce((result, output) => {
+      const stringified = typeof output === 'string' ? output : JSON.stringify(output)
+      result += stringified + ' '
+      return result
+    }, '').trim()
+    return [outputString]
+  }
 
   return preparedOutput
 }

--- a/test/node/logging-methods.test.js
+++ b/test/node/logging-methods.test.js
@@ -42,6 +42,14 @@ consoleMethods.forEach(method => {
       )
     })
 
+    it('outputs a single argument with plaintext option', () => {
+      const foo = logdown('foo', { plaintext: true })
+
+      foo[method]('one', 'two', 'three')
+
+      expect(console[method]).toHaveBeenCalledWith(foo._getDecoratedPrefix(method) + ' one two three')
+    })
+
     it('parses markdown in multiple arguments', () => {
       const foo = logdown('foo')
 


### PR DESCRIPTION
This will add a `plaintext` option to logdown which calls the logging function with only one argument.

This is needed for some environments where the logging function supports only a single argument. In my case it was Electron which logs [only the first argument](https://github.com/electron/electron/issues/8090) to the console because of an [old Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=365427).